### PR TITLE
Issue #2: add yarn script to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@ An adapter to launch multiple adapter
 
 ## Installation
 
-```
+```shell
+# Npm:
 npm install @macfja/svelte-adapter-multi
+# Yarn
+yarn install @macfja/svelte-multi-adapter
 ```
 
 ## Usage


### PR DESCRIPTION
### Description
 
The package published to the Yarn registry has a different name: `svelte-multi-adapter` instead of  `svelte-adapter-multi`

This PR adds a yarn-specific script in the Readme.md file, to avoid confusion. Having the same name on both registries would of course be even better.